### PR TITLE
Fix ⍛

### DIFF
--- a/SBCS.dyalog
+++ b/SBCS.dyalog
@@ -6,9 +6,9 @@
 ⍝   'code.dyalog' SBCS.From 'code.sbcs'
 ⍝ The result of both functions is the number of bytes written
 
-    uc   ← ,¨'⊆⍠⍤⌸⌺⍸⍥⍢√⊇…⌾⍮⍭⍧⍛' ⍝ ∥¤⍰⍛⍜
-    av   ← ,¨'ɫ¥£¢ý·€´§¶∣¿¡',⎕UCS 160 31 12⍝ 
-    cs ← av ⎕R uc⊢⎕AV
+    uc   ← '⊆⍠⍤⌸⌺⍸⍥⍢√⊇…⌾⍮⍭⍧⍛' ⍝ ∥¤⍰⍛⍜
+    av   ← 'ɫ¥£¢ý·€´§¶∣¿¡',⎕UCS 160 31 12⍝ 
+    cs ← (uc @ (⎕AV ⍳ av)) ⎕AV
     To   ← (⊢∘⎕NUNTIE⊢(¯129+cs⍳∘⊃∘⎕NGET⊣)⎕NAPPEND 83,⍨⊢)∘(⊢⎕NCREATE∘≡1∘⎕NDELETE)
     From ← ⊢⊣⎕NPUT⍨∘⊂cs{⍺[⍵]}129+∘(⎕NUNTIE⊢(⎕NREAD,∘83 ¯1))0⎕NTIE⍨⊢
 :EndNamespace


### PR DESCRIPTION
⎕UCS 12 was meant to be replaced with this, but ⎕R regex replace does not work with any characters ranging from ⎕UCS 10 to 13.